### PR TITLE
Fix MQTTException import for lint

### DIFF
--- a/pyrmqtt.py
+++ b/pyrmqtt.py
@@ -15,7 +15,7 @@ from typing import Any, Dict, List
 from xml.etree import ElementTree as ET
 
 import paho.mqtt.client as mqtt  # pip install paho-mqtt
-from paho.mqtt.client import MQTTException, WebsocketConnectionError
+from paho.mqtt.client import WebsocketConnectionError
 import raven  # pip install pyraven
 import serial
 
@@ -158,7 +158,12 @@ def connect_with_backoff(
         try:
             client.connect(host, port, keepalive=DEFAULT_KEEPALIVE)
             return
-        except (OSError, WebsocketConnectionError, MQTTException, ValueError) as err:
+        except (
+            OSError,
+            WebsocketConnectionError,
+            mqtt.MQTTException,
+            ValueError,
+        ) as err:
             log.warning("MQTT connect error=%r backoff=%.1fs", err, backoff)
         time.sleep(backoff + random.random())
         backoff = min(backoff * 2, float(DEFAULT_BACKOFF_MAX))
@@ -190,7 +195,7 @@ def publish_with_reconnect(
             retry = client.publish(topic, payload, qos=qos, retain=retain)
             if retry.rc == mqtt.MQTT_ERR_SUCCESS:
                 return
-        except (OSError, WebsocketConnectionError, MQTTException) as err:
+        except (OSError, WebsocketConnectionError, mqtt.MQTTException) as err:
             log.warning("Reconnect error=%r backoff=%.1fs", err, backoff)
         time.sleep(backoff + random.random())
         backoff = min(backoff * 2, float(DEFAULT_BACKOFF_MAX))


### PR DESCRIPTION
## Summary
- reference `MQTTException` via the imported `paho.mqtt.client` module instead of importing it directly so linting can resolve the symbol
- keep using the existing `WebsocketConnectionError` import for clarity

## Testing
- `pylint --rcfile .pylintrc *.py` *(fails in this environment because wrapt cannot be imported under Python 3.11)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d482aea7483309f3e95521f24b8ea)