### PR TITLE
Fix MQTT exception handling for docker build

### DIFF
--- a/pyrmqtt.py
+++ b/pyrmqtt.py
@@ -161,7 +161,6 @@ def connect_with_backoff(
         except (
             OSError,
             WebsocketConnectionError,
-            mqtt.MQTTException,
             ValueError,
         ) as err:
             log.warning("MQTT connect error=%r backoff=%.1fs", err, backoff)
@@ -195,7 +194,7 @@ def publish_with_reconnect(
             retry = client.publish(topic, payload, qos=qos, retain=retain)
             if retry.rc == mqtt.MQTT_ERR_SUCCESS:
                 return
-        except (OSError, WebsocketConnectionError, mqtt.MQTTException) as err:
+        except (OSError, WebsocketConnectionError) as err:
             log.warning("Reconnect error=%r backoff=%.1fs", err, backoff)
         time.sleep(backoff + random.random())
         backoff = min(backoff * 2, float(DEFAULT_BACKOFF_MAX))
@@ -287,7 +286,7 @@ def shutdown_client(client: mqtt.Client, topics: Dict[str, str], log: logging.Lo
     """Publish offline, stop the loop, and disconnect."""
     try:
         client.publish(topics["state"], "offline", qos=1, retain=True)
-    except (OSError, MQTTException):
+    except OSError:
         log.debug("Failed to publish offline state during shutdown", exc_info=True)
     client.loop_stop()
     client.disconnect()


### PR DESCRIPTION
## Summary
- stop importing the non-existent `MQTTException` symbol from `paho.mqtt.client`
- narrow the exception handlers in the MQTT connection, publish, and shutdown helpers to the supported types so pylint passes again

## Testing
- `python -m compileall pyrmqtt.py`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d4930a03c8330b94ddefd90ea1785)