### PR TITLE
Add missing docstrings for HTTP helpers

### DIFF
--- a/pvoutput_uploader.py
+++ b/pvoutput_uploader.py
@@ -156,10 +156,12 @@ def _request(
 
 
 def http_get(url: str, *, params=None, auth=None, timeout=None) -> HttpResponse:
+    """Perform a simple HTTP GET request using urllib primitives."""
     return _request("GET", url, params=params, auth=auth, timeout=timeout)
 
 
 def http_post(url: str, *, data=None, headers=None, timeout=None) -> HttpResponse:
+    """Perform an HTTP POST request with form data and optional headers."""
     return _request("POST", url, data=data, headers=headers, timeout=timeout)
 
 


### PR DESCRIPTION
## Summary
- add docstrings for the simple HTTP helper wrappers so pylint passes within Docker

## Testing
- `pylint --rcfile .pylintrc *.py` *(fails in this environment because wrapt is incompatible with Python 3.11)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d791541c883308d24892555f905d1)