### PR TITLE
Add docstrings to HttpResponse helpers

### DIFF
--- a/pvoutput_uploader.py
+++ b/pvoutput_uploader.py
@@ -100,14 +100,17 @@ class HttpResponse:
 
     @property
     def text(self) -> str:
+        """Return the body as text, caching the decoded value."""
         if self._text_cache is None:
             self._text_cache = self._content.decode("utf-8", errors="replace")
         return self._text_cache
 
     def json(self) -> dict:
+        """Parse the response body as JSON and return the result."""
         return json.loads(self.text)
 
     def raise_for_status(self) -> None:
+        """Raise RequestException if the response code indicates an error."""
         if self.status_code >= 400:
             raise RequestException(f"HTTP {self.status_code}: {self.text}")
 


### PR DESCRIPTION
## Summary
- add descriptive docstrings to the text/json/raise_for_status helpers on HttpResponse to satisfy pylint requirements

## Testing
- `pipenv run pylint --rcfile "/tmp/.pylintrc" *.py` *(fails: pipenv could not install Python 3.9 because python.org download returned HTTP 403)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d7a4354dc833087b27163f3341f1d)