### PR TITLE
Fix container entrypoint to inject CLI defaults

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,8 @@ FROM base AS runtime
 
 # Ensure all testing has been run when using BuildKit
 COPY --from=pylint /app/*.py /app/
+COPY entry.sh /app/entry.sh
+RUN chmod +x /app/entry.sh
 WORKDIR /app
 
-ENTRYPOINT ["python", "pyrmqtt.py"]
+ENTRYPOINT ["/app/entry.sh"]


### PR DESCRIPTION
## Summary
- copy the entrypoint helper script into the runtime image and use it as the container entrypoint
- ensure the entrypoint script is executable so it can inject CLI defaults from environment variables

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691d7d45a5088330bd62fdcb1510af37)